### PR TITLE
Add slim test set for ci

### DIFF
--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -97,6 +97,7 @@
 						<configuration>
 							<argLine>-Xmx4G</argLine>
 							<argLine>-Xss128m</argLine>
+							<forkCount>1C</forkCount>
 							<includes>
 								<include>test.core.**</include>
 								<include>test.cases.basic.**</include>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -106,6 +106,7 @@
 							</includes>
 							<excludes>
 								<exclude>**/*LongTest.java</exclude>
+								<exclude>test.cases.fields.WritePOITest</exclude>
 							</excludes>
 						</configuration>
 					</plugin>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -102,12 +102,10 @@
 								<include>test.core.**</include>
 								<include>test.cases.basic.**</include>
 								<include>test.cases.context.**</include>
-								<include>test.cases.fields.**</include>
 								<include>test.cases.subclassing.**</include>
 							</includes>
 							<excludes>
 								<exclude>**/*LongTest.java</exclude>
-								<exclude>test.cases.fields.WritePOITest</exclude>
 							</excludes>
 						</configuration>
 					</plugin>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -18,6 +18,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.21.0</version>
 				<configuration>
 					<argLine>-Xmx4G</argLine>
 					<argLine>-Xss128m</argLine>
@@ -83,4 +84,35 @@
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
 		</repository>
 	</repositories>
+
+	<profiles>
+		<profile>
+			<id>slimBoomerangPDSTestSet</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<version>2.21.0</version>
+						<configuration>
+							<argLine>-Xmx4G</argLine>
+							<argLine>-Xss128m</argLine>
+							<includes>
+								<include>test.core.**</include>
+								<include>test.cases.basic.**</include>
+								<include>test.cases.context.**</include>
+								<include>test.cases.exceptions.**</include>
+								<include>test.cases.fields.**</include>
+								<include>test.cases.multiqueries.**</include>
+								<include>test.cases.subclassing.**</include>
+							</includes>
+							<excludes>
+								<exclude>**/*LongTest.java</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -101,9 +101,7 @@
 								<include>test.core.**</include>
 								<include>test.cases.basic.**</include>
 								<include>test.cases.context.**</include>
-								<include>test.cases.exceptions.**</include>
 								<include>test.cases.fields.**</include>
-								<include>test.cases.multiqueries.**</include>
 								<include>test.cases.subclassing.**</include>
 							</includes>
 							<excludes>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -68,12 +68,6 @@
             <artifactId>synchronizedPDS</artifactId>
             <version>1.0.0</version>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -18,6 +18,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.21.0</version>
                 <configuration>
                     <argLine>-Xmx4G</argLine>
                     <argLine>-Xss128m</argLine>
@@ -81,4 +82,27 @@
             <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
         </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>slimBoomerangPDSTestSet</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>2.21.0</version>
+                        <configuration>
+                            <argLine>-Xmx4G</argLine>
+                            <argLine>-Xss128m</argLine>
+                            <forkCount>1C</forkCount>
+                            <excludes>
+                                <exclude>typestate.tests.PrintStreamTest</exclude>
+                            </excludes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,4 +8,4 @@ env:
 build:
   ci:
    - git checkout --recurse-submodules $NIGHTLYBUILD
-   - mvn clean verify surefire:test --fail-at-end --forkCount=1C -P slimBoomerangPDSTestSet -T 1C
+   - mvn clean verify surefire:test --fail-at-end -P slimBoomerangPDSTestSet -T 1C

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,4 +8,4 @@ env:
 build:
   ci:
    - git checkout --recurse-submodules $NIGHTLYBUILD
-   - mvn clean verify surefire:test --fail-at-end -P slimBoomerangPDSTestSet -T 1C
+   - mvn clean verify surefire:test --fail-at-end --forkCount=1C -P slimBoomerangPDSTestSet -T 1C

--- a/shippable.yml
+++ b/shippable.yml
@@ -8,4 +8,4 @@ env:
 build:
   ci:
    - git checkout --recurse-submodules $NIGHTLYBUILD
-   - mvn clean verify surefire:test --fail-at-end
+   - mvn clean verify surefire:test --fail-at-end -P slimBoomerangPDSTestSet -T 1C


### PR DESCRIPTION
So we can have the CI build and at least some tests.
Especially when for changing interfaces or the new call graph, that might make side effects a lot easier to keep track of.