### PR TITLE
Remove PathExpression as submodule and make it maven dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "PathExpression"]
-	path = PathExpression
-	url = https://github.com/johspaeth/PathExpression

--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -46,4 +46,11 @@
 			<version>2.11.0</version>
 		</dependency>
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>soot-release</id>
+			<name>soot release</name>
+			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+		</repository>
+	</repositories>
 </project>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -36,4 +36,11 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<repositories>
+		<repository>
+			<id>soot-release</id>
+			<name>soot release</name>
+			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+		</repository>
+	</repositories>
 </project>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -91,6 +91,11 @@
 			<name>soot snapshots</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
 		</repository>
+		<repository>
+			<id>soot-release</id>
+			<name>soot release</name>
+			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+		</repository>
 	</repositories>
 
 	<profiles>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -80,6 +80,11 @@
             <name>soot snapshots</name>
             <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
         </repository>
+        <repository>
+            <id>soot-release</id>
+            <name>soot release</name>
+            <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+        </repository>
     </repositories>
 
     <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,6 @@
     <module>testCore</module>
     <module>SynchronizedPDS</module>
     <module>WPDS</module>
-    <module>PathExpression</module>
     </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -51,11 +51,16 @@
 			<version>1.0.0</version>
 		</dependency>
 	</dependencies>
-	 <repositories>
-    <repository>
-      <id>soot-snapshot</id>
-      <name>soot snapshots</name>
-      <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
-    </repository>
-</repositories> 
+	<repositories>
+		<repository>
+			<id>soot-snapshot</id>
+			<name>soot snapshots</name>
+			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
+		</repository>
+		<repository>
+			<id>soot-release</id>
+			<name>soot release</name>
+			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+		</repository>
+	</repositories>
 </project>


### PR DESCRIPTION
PathExpression was deployed to soot-release, removed as a submodule (unsure how well this will work after merge), and added as maven dependency.

Soot-release is added as repository where necessary.

Note: There is no webhook for PathExpression yet.