### PR TITLE
Make snapshot versions depend on snapshot versions of other modules

### DIFF
--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>WPDS</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.google.guava</groupId>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -35,19 +35,18 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>testCore</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>WPDS</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>23.5-jre</version>
 		</dependency>
-
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>PathExpression</artifactId>
@@ -66,7 +65,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>synchronizedPDS</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -35,17 +35,17 @@
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>testCore</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>boomerangPDS</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>WPDS</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>synchronizedPDS</artifactId>
-            <version>1.0.0</version>
+            <version>1.0.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,11 @@
   <packaging>pom</packaging>
   <name>weightedBoomerang-root</name>
   <modules>
-    <module>idealPDS</module>
-    <module>boomerangPDS</module>
-    <module>testCore</module>
-    <module>SynchronizedPDS</module>
     <module>WPDS</module>
-    <module>PathExpression</module>
+    <module>SynchronizedPDS</module>
+    <module>testCore</module>
+    <module>boomerangPDS</module>
+    <module>idealPDS</module>
     </modules>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -23,7 +23,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>WPDS</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 		    <groupId>com.google.guava</groupId>
@@ -48,7 +48,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>synchronizedPDS</artifactId>
-			<version>1.0.0</version>
+			<version>1.0.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 	 <repositories>


### PR DESCRIPTION
The builds have to work with snapshot versions of their required modules (as we never build release versions).