### PR TITLE
Disable releases for soot-snapshot and snapshots for soot-release

### DIFF
--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -51,6 +51,9 @@
 			<id>soot-release</id>
 			<name>soot release</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 </project>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -41,6 +41,9 @@
 			<id>soot-release</id>
 			<name>soot release</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 </project>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -89,11 +89,17 @@
 			<id>soot-snapshot</id>
 			<name>soot snapshots</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
 		</repository>
 		<repository>
 			<id>soot-release</id>
 			<name>soot release</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -79,11 +79,17 @@
             <id>soot-snapshot</id>
             <name>soot snapshots</name>
             <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
         </repository>
         <repository>
             <id>soot-release</id>
             <name>soot release</name>
             <url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
         </repository>
     </repositories>
 </project>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -56,11 +56,17 @@
 			<id>soot-snapshot</id>
 			<name>soot snapshots</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-snapshot/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
 		</repository>
 		<repository>
 			<id>soot-release</id>
 			<name>soot release</name>
 			<url>https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
 		</repository>
 	</repositories>
 </project>


### PR DESCRIPTION
Otherwise there will be warnings like these:

```
[WARNING] Could not transfer metadata ca.mcgill.sable:soot:3.0.0-SNAPSHOT/maven-metadata.xml from/to soot-release (https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/): Failed to transfer file: https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/ca/mcgill/sable/soot/3.0.0-SNAPSHOT/maven-metadata.xml. Return code is: 400 , ReasonPhrase:Repository version policy: RELEASE does not allow metadata in path: ca/mcgill/sable/soot/3.0.0-SNAPSHOT/maven-metadata.xml.
[WARNING] Failure to transfer ca.mcgill.sable:soot:3.0.0-SNAPSHOT/maven-metadata.xml from https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/ was cached in the local repository, resolution will not be reattempted until the update interval of soot-release has elapsed or updates are forced. Original error: Could not transfer metadata ca.mcgill.sable:soot:3.0.0-SNAPSHOT/maven-metadata.xml from/to soot-release (https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/): Failed to transfer file: https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/ca/mcgill/sable/soot/3.0.0-SNAPSHOT/maven-metadata.xml. Return code is: 400 , ReasonPhrase:Repository version policy: RELEASE does not allow metadata in path: ca/mcgill/sable/soot/3.0.0-SNAPSHOT/maven-metadata.xml.
/axml/2.0.0-SNAPSHOT/maven-metadata.xml
```

I had problems understanding these and whether or not they are problematic when I started using the project, I assume others might experience it similarly. They are easily fixable and the config speeds up the build by not asking the wrong repositories.