### PR TITLE
Separate surefire reports in shippable directory

### DIFF
--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -26,7 +26,7 @@
 					<argLine>-Xmx8G -Xss128m</argLine>
 					<forkCount>1.5C</forkCount>
 					<reuseForks>true</reuseForks>
-                    <reportsDirectory>../shippable/testresults</reportsDirectory>
+                    <reportsDirectory>../shippable/testresults/boomerangPDS</reportsDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -116,10 +116,6 @@
 						<artifactId>maven-surefire-plugin</artifactId>
 						<version>2.21.0</version>
 						<configuration>
-							<argLine>-Xmx8G -Xss128m</argLine>
-							<forkCount>1.5C</forkCount>
-							<reuseForks>true</reuseForks>
-                            <reportsDirectory>../shippable/testresults</reportsDirectory>
 							<includes>
 								<include>test.core.**</include>
 								<include>test.cases.basic.**</include>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -26,7 +26,7 @@
                     <argLine>-Xmx8G -Xss128m</argLine>
                     <forkCount>1.5C</forkCount>
                     <reuseForks>true</reuseForks>
-                    <reportsDirectory>../shippable/testresults</reportsDirectory>
+                    <reportsDirectory>../shippable/testresults/idealPDS</reportsDirectory>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Solves #35 

Jenkins tests & reports every module now, Shippable test every module and reports boomerangPDS and idealPDS (others do not have a shippable directory for report output)