### PR TITLE
Inhibit download output on shippable

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -5,4 +5,4 @@ jdk:
 
 build:
   ci:
-   - mvn verify --fail-at-end
+   - mvn verify --fail-at-end -B


### PR DESCRIPTION
Use maven batch mode which will avoid printing download progress and thus make output more readable on shippable (Jenkins does the same thing by default). Maven will still print information when a download fails.

Will prevent this:
```

Downloaded: https://repo.maven.apache.org/maven2/com/google/errorprone/error_prone_parent/2.0.18/error_prone_parent-2.0.18.pom (5 KB at 148.6 KB/sec)
Downloading: https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
         
Downloading: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom
3/3 KB   
3/3 KB   
         
Downloaded: https://repo.maven.apache.org/maven2/com/google/j2objc/j2objc-annotations/1.1/j2objc-annotations-1.1.pom (3 KB at 74.9 KB/sec)
Downloading: https://soot-build.cs.uni-paderborn.de/nexus/repository/soot-release/org/codehaus/mojo/animal-sniffer-annotations/1.14/animal-sniffer-annotations-1.14.pom
```
