### PR TITLE
Demand driven icfg reset

### DIFF
--- a/boomerangPDS/src/main/java/boomerang/callgraph/BackwardsObservableICFG.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/BackwardsObservableICFG.java
@@ -116,4 +116,9 @@ public class BackwardsObservableICFG implements ObservableICFG<Unit, SootMethod>
         return delegate.getNumberOfEdgesTakenFromPrecomputedGraph();
     }
 
+    @Override
+    public void resetCallGraph() {
+        delegate.resetCallGraph();
+    }
+
 }

--- a/boomerangPDS/src/main/java/boomerang/callgraph/ObservableDynamicICFG.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/ObservableDynamicICFG.java
@@ -414,4 +414,13 @@ public class ObservableDynamicICFG<W extends Weight> implements ObservableICFG<U
         return numberOfEdgesTakenFromPrecomputedCallGraph;
     }
 
+    @Override
+    public void resetCallGraph() {
+        demandDrivenCallGraph = new CallGraph();
+        numberOfEdgesTakenFromPrecomputedCallGraph = 0;
+        methodsWithCallFlow.clear();
+        calleeListeners.clear();
+        callerListeners.clear();
+    }
+
 }

--- a/boomerangPDS/src/main/java/boomerang/callgraph/ObservableICFG.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/ObservableICFG.java
@@ -111,4 +111,11 @@ public interface ObservableICFG<N,M> {
 
 	int getNumberOfEdgesTakenFromPrecomputedGraph();
 
+    /**
+     * Resets the call graph. Only affects the call graph if it was built demand-driven, otherwise
+     * graph will remain unchanged. Demand-driven call graph will keep intraprocedual information, but reset
+     * start with an empty call graph again.
+     */
+	void resetCallGraph();
+
 }

--- a/boomerangPDS/src/main/java/boomerang/callgraph/ObservableStaticICFG.java
+++ b/boomerangPDS/src/main/java/boomerang/callgraph/ObservableStaticICFG.java
@@ -158,5 +158,8 @@ public class ObservableStaticICFG implements ObservableICFG<Unit, SootMethod>{
         return -1;
     }
 
-
+    @Override
+    public void resetCallGraph() {
+        //Static call graph does not need to be reset, ignore this
+    }
 }

--- a/idealPDS/src/main/java/ideal/IDEALAnalysis.java
+++ b/idealPDS/src/main/java/ideal/IDEALAnalysis.java
@@ -79,6 +79,9 @@ public class IDEALAnalysis<W extends Weight> {
 			Stopwatch watch = Stopwatch.createStarted();
 			analysisTime.put(seed, watch);
 			ForwardBoomerangResults<W> res;
+			//Reset the call graph when dealing with a new seed. Will only affect demand-driven call graphs.
+			if (analysisDefinition.icfg() != null)
+				analysisDefinition.icfg().resetCallGraph();
 			try {
 				res = run(seed);
 			} catch(IDEALSeedTimeout e){


### PR DESCRIPTION
I cherry picked the new reset function from the `observable-dynamic-icfg` branch (which I used to evaluate per seed). Since `demand-driven-icfg` is the most up-to-date and best working version, I suggest we add that functionality in there as well.