### PR TITLE
Put all tests results into subfolders of shippable/testresults

### DIFF
--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -13,8 +13,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -17,6 +17,17 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.21.0</version>
+				<configuration>
+					<argLine>-Xmx8G -Xss128m</argLine>
+					<forkCount>1.5C</forkCount>
+					<reuseForks>true</reuseForks>
+					<reportsDirectory>../shippable/testresults/synchronizedPDS</reportsDirectory>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -20,7 +20,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.12.4</version>
+				<version>2.21.0</version>
 				<configuration>
 					<argLine>-Xmx8G -Xss128m</argLine>
 					<reportsDirectory>../shippable/testresults/synchronizedPDS</reportsDirectory>

--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -20,11 +20,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
+				<version>2.12.4</version>
 				<configuration>
 					<argLine>-Xmx8G -Xss128m</argLine>
-					<forkCount>1.5C</forkCount>
-					<reuseForks>true</reuseForks>
 					<reportsDirectory>../shippable/testresults/synchronizedPDS</reportsDirectory>
 				</configuration>
 			</plugin>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -4,14 +4,17 @@
 	<groupId>de.fraunhofer.iem</groupId>
 	<artifactId>WPDS</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -17,11 +17,9 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.21.0</version>
+				<version>2.12.4</version>
 				<configuration>
 					<argLine>-Xmx8G -Xss128m</argLine>
-					<forkCount>1.5C</forkCount>
-					<reuseForks>true</reuseForks>
 					<reportsDirectory>../shippable/testresults/WPDS</reportsDirectory>
 				</configuration>
 			</plugin>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -14,6 +14,17 @@
 					<target>1.7</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.21.0</version>
+				<configuration>
+					<argLine>-Xmx8G -Xss128m</argLine>
+					<forkCount>1.5C</forkCount>
+					<reuseForks>true</reuseForks>
+					<reportsDirectory>../shippable/testresults/WPDS</reportsDirectory>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 	<dependencies>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -12,8 +12,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.3</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
This should cause shippable to detect all tests. 

However, synchronizedPDS and WPDS have a lower surefire version than the boomerang/ideal. They both started to experience test failures with the newer version. I suspect this could be the fact that they are configured to use Java 7 instead of 8. I think it might be good for the general code quality to have consistent versions across the project.