### PR TITLE
make TimeoutException public 

### DIFF
--- a/SynchronizedPDS/pom.xml
+++ b/SynchronizedPDS/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>de.fraunhofer.iem</groupId>
 		<artifactId>SPDS</artifactId>
-		<version>2.5-SNAPSHOT</version>
+		<version>2.5.1-SNAPSHOT</version>
     	<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -25,7 +25,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>WPDS</artifactId>
-			<version>2.5-SNAPSHOT</version>
+			<version>2.5.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/WPDS/pom.xml
+++ b/WPDS/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>de.fraunhofer.iem</groupId>
 		<artifactId>SPDS</artifactId>
-	    <version>2.5-SNAPSHOT</version>
+	    <version>2.5.1-SNAPSHOT</version>
     	<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -26,12 +26,12 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>testCore</artifactId>
-			<version>2.5-SNAPSHOT</version>
+			<version>2.5.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>WPDS</artifactId>
-			<version>2.5-SNAPSHOT</version>
+			<version>2.5.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>synchronizedPDS</artifactId>
-			<version>2.5-SNAPSHOT</version>
+			<version>2.5.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.googlecode.json-simple</groupId>

--- a/boomerangPDS/pom.xml
+++ b/boomerangPDS/pom.xml
@@ -4,7 +4,7 @@
     <parent>
 		<groupId>de.fraunhofer.iem</groupId>
 		<artifactId>SPDS</artifactId>
-		<version>2.5-SNAPSHOT</version>
+		<version>2.5.1-SNAPSHOT</version>
     	<relativePath>../pom.xml</relativePath>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>

--- a/boomerangPDS/src/main/java/boomerang/BoomerangTimeoutException.java
+++ b/boomerangPDS/src/main/java/boomerang/BoomerangTimeoutException.java
@@ -13,7 +13,7 @@ package boomerang;
 
 import boomerang.stats.IBoomerangStats;
 
-class BoomerangTimeoutException extends RuntimeException {
+public class BoomerangTimeoutException extends RuntimeException {
 
     private IBoomerangStats stats;
     private long elapsed;

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>boomerangPDS</artifactId>
-            <version>2.5-SNAPSHOT</version>
+            <version>2.5.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>

--- a/idealPDS/pom.xml
+++ b/idealPDS/pom.xml
@@ -3,7 +3,7 @@
    <parent>
 		<groupId>de.fraunhofer.iem</groupId>
 		<artifactId>SPDS</artifactId>
-		<version>2.5-SNAPSHOT</version>
+		<version>2.5.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
 	</parent>
     <modelVersion>4.0.0</modelVersion>
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>testCore</artifactId>
-            <version>2.5-SNAPSHOT</version>
+            <version>2.5.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>de.fraunhofer.iem</groupId>
             <artifactId>WPDS</artifactId>
-            <version>2.5-SNAPSHOT</version>
+            <version>2.5.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>de.fraunhofer.iem</groupId>
 	<artifactId>SPDS</artifactId>
-	<version>2.5-SNAPSHOT</version>
+	<version>2.5.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>SPDS</name>
 	<modules>

--- a/testCore/pom.xml
+++ b/testCore/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 	    <groupId>de.fraunhofer.iem</groupId>
 	    <artifactId>SPDS</artifactId>
-	    <version>2.5-SNAPSHOT</version>
+	    <version>2.5.1-SNAPSHOT</version>
     	<relativePath>../pom.xml</relativePath>
   	</parent>
 	<modelVersion>4.0.0</modelVersion>
@@ -13,7 +13,7 @@
 		<dependency>
 			<groupId>de.fraunhofer.iem</groupId>
 			<artifactId>WPDS</artifactId>
-			<version>2.5-SNAPSHOT</version>
+			<version>2.5.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>


### PR DESCRIPTION
The `checkTimeout()` method which throws this exception is also public and overrideable (as it should be). Thus the exception has to be public as well to define a custom timeout logic.